### PR TITLE
Add 'GitHub Skills' activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Hands-on workshops teaching Git, GitHub, and collaboration workflows",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
Adds the missing "GitHub Skills" activity to the activities list. This closes issue #6 by adding the activity so students can register.

Changes:
- Added `GitHub Skills` entry to `src/app.py` activities dictionary.

Please review and merge.